### PR TITLE
Added sessionStorage Support for Input Reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,11 @@
         <label>Education</label>
         <div id="education-inputs">
           <div class="education-inputs fade-in">
-            <input type="text" placeholder="Institution" class="education-institution" />
-            <input type="text" placeholder="Degree" class="education-degree" />
-            <input type="text" placeholder="GPA" class="education-gpa" />
-            <input type="text" placeholder="Location" class="education-location" />
-            <input type="text" placeholder="Dates" class="education-dates" />
+            <input type="text" placeholder="Institution" class="education-institution" id="education-institution" />
+            <input type="text" placeholder="Degree" class="education-degree" id="education-degree" />
+            <input type="text" placeholder="GPA" class="education-gpa" id="education-gpa"/>
+            <input type="text" placeholder="Location" class="education-location" id="education-location" />
+            <input type="text" placeholder="Dates" class="education-dates" id="education-dates" />
           </div>
         </div>
         <button type="button" id="add-education" class="add-btn fade-in">+ Add Education</button>
@@ -113,11 +113,11 @@
         <label>Work Experience</label>
         <div id="experience-inputs">
           <div class="experience-inputs fade-in">
-            <input type="text" placeholder="Role" class="experience-role" />
-            <input type="text" placeholder="Company" class="experience-company" />
-            <input type="text" placeholder="Company Link" class="experience-link" />
-            <input type="text" placeholder="Dates" class="experience-dates" />
-            <textarea placeholder="Key achievements (1 per line)" class="experience-desc"></textarea>
+            <input type="text" placeholder="Role" class="experience-role" id="experience-role" />
+            <input type="text" placeholder="Company" class="experience-company" id="experience-company" />
+            <input type="text" placeholder="Company Link" class="experience-link" id="experience-link" />
+            <input type="text" placeholder="Dates" class="experience-dates" id="experience-dates" />
+            <textarea placeholder="Key achievements (1 per line)" id="experience-desc" class="experience-desc"></textarea>
           </div>
         </div>
         <button type="button" id="add-experience" class="add-btn fade-in">+ Add Experience</button>
@@ -128,10 +128,10 @@
         <label>Certificates</label>
         <div id="certifications-inputs">
           <div class="certifications-inputs fade-in">
-            <input type="text" placeholder="Certificate Name" class="certificate-title" />
-            <input type="text" placeholder="Issuing Organization" class="certificate-issuer" />
-            <input type="text" placeholder="Date" class="certificate-date" />
-            <textarea placeholder="Description (1 per line)" class="certificate-desc"></textarea>
+            <input type="text" placeholder="Certificate Name" class="certificate-title" id="certificate-title" />
+            <input type="text" placeholder="Issuing Organization" class="certificate-issuer" id="certificate-issuer" />
+            <input type="text" placeholder="Date" class="certificate-date" id="certificate-date"/>
+            <textarea placeholder="Description (1 per line)" id="certificate-desc" class="certificate-desc"></textarea>
           </div>
         </div>
         <button type="button" id="add-certificate" class="add-btn fade-in">+ Add Certificate</button>
@@ -142,9 +142,9 @@
         <label>Projects</label>
         <div id="projects-inputs">
           <div class="project-input ">
-            <input type="text" placeholder="Project Title" class="project-title" />
-            <input type="url" placeholder="Project Link (URL)" class="project-link" />
-            <textarea placeholder="Key achievements (1 per line)" class="project-desc"></textarea>
+            <input type="text" placeholder="Project Title" class="project-title" id="project-title" />
+            <input type="url" placeholder="Project Link (URL)" class="project-link" id="project-link" />
+            <textarea placeholder="Key achievements (1 per line)" id="project-desc" class="project-desc"></textarea>
           </div>
         </div>
         <button type="button" id="add-project" class="add-btn fade-in">+ Add Project</button>
@@ -243,7 +243,7 @@
         
       </div> <!-- /resume-sections -->
       <div class="footer-actions no-print">
-          <button class="btn-refresh" onclick="window.location.reload();">🔄 Refresh Resume</button>
+          <button class="btn-refresh" onclick="clearAndReload()">🔄 Refresh Resume</button>
           <br />
           <button class="btn-autofill" onclick="autofillResume()">✍️ Autofill Resume</button>
         </div>

--- a/script.js
+++ b/script.js
@@ -357,11 +357,11 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     container.addEventListener("dragend", function (e) {
-    if (draggedItem) {
-        draggedItem.classList.remove("dragging");
-        saveCurrentOrder(); // Save new order
-        draggedItem = null;
-    }
+        if (draggedItem) {
+            draggedItem.classList.remove("dragging");
+            saveCurrentOrder(); // Save new order
+            draggedItem = null;
+        }
     });
 
     container.addEventListener("dragover", function (e) {
@@ -414,4 +414,70 @@ scrollUpBtn.addEventListener("click", () => {
       restoreOrder(next);
     }
   }); */
-  
+
+// Storing Inputs to SessionStorage
+function saveToSessionStorage(id) {
+    const input = document.getElementById(id)
+    if (input) {
+        input.addEventListener("input", () => {
+            sessionStorage.setItem(id, input.value)
+        })
+    }
+}
+
+function loadFromSessionStorage(id) {
+    const input = document.getElementById(id)
+    const storedInput = sessionStorage.getItem(id)
+
+    if (input && (storedInput != null)) {
+        input.value = storedInput
+        input.dispatchEvent(new Event("input"))
+    }
+
+}
+document.addEventListener("DOMContentLoaded", () => {
+    const inputIds = [
+        "input-name",
+        "input-email",
+        "input-phone",
+        "input-linkedin",
+        "input-github",
+        "input-about",
+        "input-languages",
+        "input-frameworks",
+        "input-tools",
+        "input-platforms",
+        "input-soft-skills",
+        "education-institution",
+        "education-degree",
+        "education-gpa",
+        "education-location",
+        "education-dates",
+        "experience-role",
+        "experience-company",
+        "experience-link",
+        "experience-dates",
+        "certificate-title",
+        "certificate-issuer",
+        "certificate-date",
+        "project-title",
+        "project-link",
+        "experience-desc",
+        "certificate-desc",
+        "project-desc",
+    ];
+
+    const textareaClass = [
+        "",
+    ]
+
+    inputIds.forEach(id => {
+        saveToSessionStorage(id); 
+        loadFromSessionStorage(id); 
+    });
+});
+
+function clearAndReload() {
+  sessionStorage.clear();        
+  window.location.reload();
+}


### PR DESCRIPTION
##  Feature: Added sessionStorage Support for Input Persistence

###  Description
This PR implements session-based data persistence for all static input fields (e.g., name, email, about, skills, etc.) in the Resume Generator form. Now, user input will remain available **during the same browser session**, even after reloads.

###  Issue Fixed
Previously, all input fields were cleared upon page refresh or accidental reload, which could cause loss of user-entered data.

###  Why `sessionStorage`?
While `localStorage` was considered, we chose `sessionStorage` for the following reasons:
- Prevents confusion if the user opens multiple resume tabs.
- Keeps resumes independent and isolated per session.
- Avoids long-term data clutter for one-time resume creation tools.


---

###  Additional Notes
Let me know if you'd like to implement a toggle between `sessionStorage` and `localStorage`, or auto-clear on tab close. I'm happy to contribute further.

---

 This PR is submitted as part of my contribution to **GirlScript Summer of Code (GSSoC)**.
 Please add **suitable labels** to this Pull Request
 
 closes #69 